### PR TITLE
Tags!

### DIFF
--- a/packages/service/src/domain/commands/processors/tag-add-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-add-command.ts
@@ -22,7 +22,8 @@ const tagAddCommandDefinition: CommandDefinition = {
   processor: tagAddCommandProcessor,
   helpMessage: 'Dodaje tag do podanego dźwięku',
   helpUsages: [
-    '<tag-name> <sound name>',
+    '<tag-name>|<sound name>',
+    'fun stuff|airhorn',
   ],
 };
 

--- a/packages/service/src/domain/commands/processors/tag-add-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-add-command.ts
@@ -1,0 +1,29 @@
+import Command from '../model/command';
+import CommandProcessingResponse, { makeSingleTextProcessingResponse } from '../model/command-processing-response';
+import CommandDefinition from '../model/command-definition';
+import XSoundsService from '../../x-sounds/x-sounds-service';
+
+async function tagAddCommandProcessor(command: Command): Promise<CommandProcessingResponse> {
+  const commandArgs = command.getArgsByDelimiter('|');
+
+  if (commandArgs.length < 2) {
+    throw new Error('Zbyt mała liczba argumentów');
+  }
+
+  const [tagName, soundName] = commandArgs;
+
+  await XSoundsService.instance.addTag(soundName, tagName);
+  return makeSingleTextProcessingResponse(`Dodano tag "${tagName}" do dźwięku ${soundName}`, false);
+}
+
+const tagAddCommandDefinition: CommandDefinition = {
+  key: 'tag-add',
+  shortKey: 'ta',
+  processor: tagAddCommandProcessor,
+  helpMessage: 'Dodaje tag do podanego dźwięku',
+  helpUsages: [
+    '<tag-name> <sound name>',
+  ],
+};
+
+export default tagAddCommandDefinition;

--- a/packages/service/src/domain/commands/processors/tag-list-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-list-command.ts
@@ -18,6 +18,7 @@ async function tagListCommandProcessor(_: Command): Promise<CommandProcessingRes
 
 const tagListCommandDefinition: CommandDefinition = {
   key: 'tag-list',
+  shortKey: 'tl',
   processor: tagListCommandProcessor,
   helpMessage: 'Wyświetla wszystkie unikatowe tagi',
 };

--- a/packages/service/src/domain/commands/processors/tag-list-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-list-command.ts
@@ -1,0 +1,25 @@
+import CommandDefinition from '../model/command-definition';
+import CommandProcessingResponse from '../model/command-processing-response';
+import Command from '../model/command';
+import XSoundsService from '../../x-sounds/x-sounds-service';
+
+async function tagListCommandProcessor(_: Command): Promise<CommandProcessingResponse> {
+  const tags = await XSoundsService.instance.getAllUniqueTags();
+  const tagListText = tags.join('\n');
+
+  return {
+    messages: [
+      { type: 'HEADER', text: 'Wszystkie tagi' },
+      { type: 'MARKDOWN', text: tagListText },
+    ],
+    isVisibleToIssuerOnly: false,
+  };
+}
+
+const tagListCommandDefinition: CommandDefinition = {
+  key: 'tag-list',
+  processor: tagListCommandProcessor,
+  helpMessage: 'Wyświetla wszystkie unikatowe tagi',
+};
+
+export default tagListCommandDefinition;

--- a/packages/service/src/domain/commands/processors/tag-remove-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-remove-command.ts
@@ -1,0 +1,28 @@
+import Command from '../model/command';
+import CommandProcessingResponse, { makeSingleTextProcessingResponse } from '../model/command-processing-response';
+import CommandDefinition from '../model/command-definition';
+import XSoundsService from '../../x-sounds/x-sounds-service';
+
+async function tagRemoveCommandProcessor(command: Command): Promise<CommandProcessingResponse> {
+  const commandArgs = command.getArgsByDelimiter('|');
+
+  if (commandArgs.length < 2) {
+    throw new Error('Zbyt mała liczba argumentów');
+  }
+
+  const [tagName, soundName] = commandArgs;
+
+  await XSoundsService.instance.removeTag(soundName, tagName);
+  return makeSingleTextProcessingResponse(`Usunięto tag "${tagName}" z dźwięku ${soundName}`, false);
+}
+
+const tagRemoveCommandDefinition: CommandDefinition = {
+  key: 'tag-remove',
+  processor: tagRemoveCommandProcessor,
+  helpMessage: 'Usuwa tag z podanego dźwięku',
+  helpUsages: [
+    '<tag-name> <sound name>',
+  ],
+};
+
+export default tagRemoveCommandDefinition;

--- a/packages/service/src/domain/commands/processors/tag-remove-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-remove-command.ts
@@ -21,7 +21,8 @@ const tagRemoveCommandDefinition: CommandDefinition = {
   processor: tagRemoveCommandProcessor,
   helpMessage: 'Usuwa tag z podanego dźwięku',
   helpUsages: [
-    '<tag-name> <sound name>',
+    '<tag-name>|<sound name>',
+    'fun stuff|airhorn',
   ],
 };
 

--- a/packages/service/src/domain/commands/processors/tag-search-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-search-command.ts
@@ -1,0 +1,35 @@
+import XSoundsService from '../../x-sounds/x-sounds-service';
+import Command from '../model/command';
+import CommandDefinition from '../model/command-definition';
+import CommandProcessingResponse from '../model/command-processing-response';
+
+async function tagSearchCommandProcessor(command: Command): Promise<CommandProcessingResponse> {
+  const tagName = command.rawArgs.trim();
+  if (!tagName) {
+    throw new Error('Podaj nazwę tagu');
+  }
+
+  const sounds = await XSoundsService.instance.getAllByTag(tagName);
+  const tagListText = sounds.map((sound) => sound.name).join('\n');
+
+  return {
+    messages: [
+      { type: 'HEADER', text: `Dźwięki z tagiem ${tagName}` },
+      { type: 'MARKDOWN', text: tagListText },
+    ],
+    isVisibleToIssuerOnly: false,
+  };
+}
+
+const tagSearchCommandDefinition: CommandDefinition = {
+  key: 'tag-search',
+  shortKey: 'ts',
+  processor: tagSearchCommandProcessor,
+  helpMessage: 'Wyszukuje dźwięki z danym tagiem',
+  helpUsages: [
+    '<tag name>',
+    'fun stuff',
+  ],
+};
+
+export default tagSearchCommandDefinition;

--- a/packages/service/src/domain/commands/processors/tag-show-command.ts
+++ b/packages/service/src/domain/commands/processors/tag-show-command.ts
@@ -1,0 +1,34 @@
+import XSoundsService from '../../x-sounds/x-sounds-service';
+import Command from '../model/command';
+import CommandDefinition from '../model/command-definition';
+import CommandProcessingResponse from '../model/command-processing-response';
+
+async function tagShowCommandProcessor(command: Command): Promise<CommandProcessingResponse> {
+  const soundName = command.rawArgs.trim();
+  if (!soundName) {
+    throw new Error('Podaj nazwę dźwięku');
+  }
+
+  const tags = await XSoundsService.instance.getSoundTags(soundName);
+  const tagListText = tags.join('\n');
+
+  return {
+    messages: [
+      { type: 'HEADER', text: `${soundName} tags` },
+      { type: 'MARKDOWN', text: tagListText },
+    ],
+    isVisibleToIssuerOnly: false,
+  };
+}
+
+const tagShowCommandDefinition: CommandDefinition = {
+  key: 'tag-show',
+  processor: tagShowCommandProcessor,
+  helpMessage: 'Wyświetla wszystkie tagi przypisane do dźwięku',
+  helpUsages: [
+    '<sound name>',
+    'airhorn',
+  ],
+};
+
+export default tagShowCommandDefinition;

--- a/packages/service/src/domain/commands/processors/x-command.ts
+++ b/packages/service/src/domain/commands/processors/x-command.ts
@@ -6,7 +6,7 @@ import { PlayXSoundEvent } from '../../../event-stream/model/events';
 import PlayerEventStream from '../../../event-stream/player-event-stream';
 
 async function xCommandProcessor(command: Command): Promise<CommandProcessingResponse> {
-  const soundName = command.rawArgs;
+  const soundName = command.rawArgs.trim();
   if (!soundName) {
     throw new Error('Podaj nazwę dźwięku');
   }

--- a/packages/service/src/domain/commands/processors/x-command.ts
+++ b/packages/service/src/domain/commands/processors/x-command.ts
@@ -7,6 +7,10 @@ import PlayerEventStream from '../../../event-stream/player-event-stream';
 
 async function xCommandProcessor(command: Command): Promise<CommandProcessingResponse> {
   const soundName = command.rawArgs;
+  if (!soundName) {
+    throw new Error('Podaj nazwę dźwięku');
+  }
+
   const xSound = await XSoundService.instance.getByName(soundName);
 
   const playXSoundEvent: PlayXSoundEvent = {

--- a/packages/service/src/domain/commands/registry/command-initializer.ts
+++ b/packages/service/src/domain/commands/registry/command-initializer.ts
@@ -1,6 +1,6 @@
-import CommandRegistryService from './command-registry-service';
 import AddCommand from '../processors/add-command';
 import AddXCommand from '../processors/add-x-command';
+import CommandRegistryService from './command-registry-service';
 import HelpCommand from '../processors/help-command';
 import ListXCommand from '../processors/list-x-command';
 import PauseCommand from '../processors/pause-command';
@@ -11,13 +11,13 @@ import SayCommand from '../processors/say-command';
 import SearchCommand from '../processors/search-command';
 import SkipCommand from '../processors/skip-command';
 import SpeedCommand from '../processors/speed-command';
+import TagAddCommand from '../processors/tag-add-command';
+import TagList from '../processors/tag-list-command';
+import TagRemove from '../processors/tag-remove-command';
+import TagSearch from '../processors/tag-search-command';
+import TagShow from '../processors/tag-show-command';
 import VolumeCommand from '../processors/volume-command';
 import XCommand from '../processors/x-command';
-import TagAddCommand from '../processors/tag-add-command';
-import TagRemove from '../processors/tag-remove-command';
-import TagShow from '../processors/tag-show-command';
-import TagList from '../processors/tag-list-command';
-import TagSearch from '../processors/tag-search-command';
 
 function initialize(): void {
   [
@@ -33,13 +33,13 @@ function initialize(): void {
     SearchCommand,
     SkipCommand,
     SpeedCommand,
-    VolumeCommand,
     TagAddCommand,
     TagList,
     TagRemove,
-    XCommand,
-    TagShow,
     TagSearch,
+    TagShow,
+    VolumeCommand,
+    XCommand,
   ].forEach((command) => CommandRegistryService.instance.register(command));
 }
 

--- a/packages/service/src/domain/commands/registry/command-initializer.ts
+++ b/packages/service/src/domain/commands/registry/command-initializer.ts
@@ -14,6 +14,7 @@ import SpeedCommand from '../processors/speed-command';
 import VolumeCommand from '../processors/volume-command';
 import XCommand from '../processors/x-command';
 import TagAddCommand from '../processors/tag-add-command';
+import TagRemove from '../processors/tag-remove-command';
 
 function initialize(): void {
   [
@@ -31,6 +32,7 @@ function initialize(): void {
     SpeedCommand,
     VolumeCommand,
     TagAddCommand,
+    TagRemove,
     XCommand,
   ].forEach((command) => CommandRegistryService.instance.register(command));
 }

--- a/packages/service/src/domain/commands/registry/command-initializer.ts
+++ b/packages/service/src/domain/commands/registry/command-initializer.ts
@@ -15,6 +15,7 @@ import VolumeCommand from '../processors/volume-command';
 import XCommand from '../processors/x-command';
 import TagAddCommand from '../processors/tag-add-command';
 import TagRemove from '../processors/tag-remove-command';
+import TagShow from '../processors/tag-show-command';
 
 function initialize(): void {
   [
@@ -34,6 +35,7 @@ function initialize(): void {
     TagAddCommand,
     TagRemove,
     XCommand,
+    TagShow,
   ].forEach((command) => CommandRegistryService.instance.register(command));
 }
 

--- a/packages/service/src/domain/commands/registry/command-initializer.ts
+++ b/packages/service/src/domain/commands/registry/command-initializer.ts
@@ -17,6 +17,7 @@ import TagAddCommand from '../processors/tag-add-command';
 import TagRemove from '../processors/tag-remove-command';
 import TagShow from '../processors/tag-show-command';
 import TagList from '../processors/tag-list-command';
+import TagSearch from '../processors/tag-search-command';
 
 function initialize(): void {
   [
@@ -38,6 +39,7 @@ function initialize(): void {
     TagRemove,
     XCommand,
     TagShow,
+    TagSearch,
   ].forEach((command) => CommandRegistryService.instance.register(command));
 }
 

--- a/packages/service/src/domain/commands/registry/command-initializer.ts
+++ b/packages/service/src/domain/commands/registry/command-initializer.ts
@@ -16,6 +16,7 @@ import XCommand from '../processors/x-command';
 import TagAddCommand from '../processors/tag-add-command';
 import TagRemove from '../processors/tag-remove-command';
 import TagShow from '../processors/tag-show-command';
+import TagList from '../processors/tag-list-command';
 
 function initialize(): void {
   [
@@ -33,6 +34,7 @@ function initialize(): void {
     SpeedCommand,
     VolumeCommand,
     TagAddCommand,
+    TagList,
     TagRemove,
     XCommand,
     TagShow,

--- a/packages/service/src/domain/commands/registry/command-initializer.ts
+++ b/packages/service/src/domain/commands/registry/command-initializer.ts
@@ -13,6 +13,7 @@ import SkipCommand from '../processors/skip-command';
 import SpeedCommand from '../processors/speed-command';
 import VolumeCommand from '../processors/volume-command';
 import XCommand from '../processors/x-command';
+import TagAddCommand from '../processors/tag-add-command';
 
 function initialize(): void {
   [
@@ -29,6 +30,7 @@ function initialize(): void {
     SkipCommand,
     SpeedCommand,
     VolumeCommand,
+    TagAddCommand,
     XCommand,
   ].forEach((command) => CommandRegistryService.instance.register(command));
 }

--- a/packages/service/src/domain/x-sounds/x-sound.ts
+++ b/packages/service/src/domain/x-sounds/x-sound.ts
@@ -5,6 +5,7 @@ interface XSound {
   name: string,
   url: string,
   timesPlayed: number,
+  tags?: string[],
 }
 
 export default XSound;

--- a/packages/service/src/domain/x-sounds/x-sounds-repository.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-repository.ts
@@ -10,6 +10,10 @@ class XSoundsRepository extends Repository<XSound> {
     return this.collection.find({}).sort({ name: 1 }).toArray();
   }
 
+  findAllByTagOrderByNameAsc(tag: string): Promise<XSound[]> {
+    return this.collection.find({ tags: tag }).sort({ name: 1 }).toArray();
+  }
+
   findByName(name: string): Promise<XSound | null> {
     return this.collection.findOne({ name });
   }

--- a/packages/service/src/domain/x-sounds/x-sounds-service.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-service.ts
@@ -107,6 +107,7 @@ class XSoundsService {
       name,
       url,
       timesPlayed,
+      tags: [],
     };
 
     await this.repository.insert(xSound);

--- a/packages/service/src/domain/x-sounds/x-sounds-service.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-service.ts
@@ -56,6 +56,28 @@ class XSoundsService {
     await this.repository.replace(updatedSound);
   }
 
+  async removeTag(soundName: string, tag: string): Promise<void> {
+    const xSound = await this.repository.findByName(soundName);
+
+    if (!xSound) {
+      throw new Error(`Dźwięk "${soundName}" nie istnieje`);
+    }
+
+    const tags = (xSound.tags || []);
+
+    const searchIndex = tags.indexOf(tag);
+    if (searchIndex > -1) {
+      tags.splice(searchIndex, 1);
+    }
+
+    const updatedSound = {
+      ...xSound,
+      tags,
+    };
+
+    await this.repository.replace(updatedSound);
+  }
+
   async createNewSound(name: string, url: string, timesPlayed = 0): Promise<void> {
     const exists = await this.soundExists(name);
     if (exists) {

--- a/packages/service/src/domain/x-sounds/x-sounds-service.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-service.ts
@@ -50,7 +50,7 @@ class XSoundsService {
     const tags = (xSound.tags || []);
     const updatedSound = {
       ...xSound,
-      tags: [...tags, tag],
+      tags: Array.from(new Set([...tags, tag])),
     };
 
     await this.repository.replace(updatedSound);

--- a/packages/service/src/domain/x-sounds/x-sounds-service.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-service.ts
@@ -88,6 +88,15 @@ class XSoundsService {
     return (xSound.tags || []);
   }
 
+  async getAllUniqueTags(): Promise<string[]> {
+    const sounds = await this.getAll();
+    const tags = sounds.flatMap((sound) => (sound.tags || []));
+    const uniqueTags = Array.from(new Set(tags));
+    const sortedTags = uniqueTags.sort();
+
+    return sortedTags;
+  }
+
   async createNewSound(name: string, url: string, timesPlayed = 0): Promise<void> {
     const exists = await this.soundExists(name);
     if (exists) {

--- a/packages/service/src/domain/x-sounds/x-sounds-service.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-service.ts
@@ -78,6 +78,16 @@ class XSoundsService {
     await this.repository.replace(updatedSound);
   }
 
+  async getSoundTags(soundName: string): Promise<string[]> {
+    const xSound = await this.repository.findByName(soundName);
+
+    if (!xSound) {
+      throw new Error(`Dźwięk "${soundName}" nie istnieje`);
+    }
+
+    return (xSound.tags || []);
+  }
+
   async createNewSound(name: string, url: string, timesPlayed = 0): Promise<void> {
     const exists = await this.soundExists(name);
     if (exists) {

--- a/packages/service/src/domain/x-sounds/x-sounds-service.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-service.ts
@@ -40,6 +40,22 @@ class XSoundsService {
     }
   }
 
+  async addTag(soundName: string, tag: string): Promise<void> {
+    const xSound = await this.repository.findByName(soundName);
+
+    if (!xSound) {
+      throw new Error(`Dźwięk "${soundName}" nie istnieje`);
+    }
+
+    const tags = (xSound.tags || []);
+    const updatedSound = {
+      ...xSound,
+      tags: [...tags, tag],
+    };
+
+    await this.repository.replace(updatedSound);
+  }
+
   async createNewSound(name: string, url: string, timesPlayed = 0): Promise<void> {
     const exists = await this.soundExists(name);
     if (exists) {

--- a/packages/service/src/domain/x-sounds/x-sounds-service.ts
+++ b/packages/service/src/domain/x-sounds/x-sounds-service.ts
@@ -22,6 +22,10 @@ class XSoundsService {
     return xSound;
   }
 
+  async getAllByTag(tag: string): Promise<XSound[]> {
+    return this.repository.findAllByTagOrderByNameAsc(tag);
+  }
+
   async soundExists(soundName: string): Promise<boolean> {
     const xSound = await this.repository.findByName(soundName);
     return !!xSound;


### PR DESCRIPTION
This PR adds tagging system for XSounds and introduces five new commands to manage them:
- `/fm tag-list`
- `/fm tag-search`
- `/fm tag-show`
- `/fm tag-add`
- `/fm tag-remove`

I've also fixed some validation issues for `/fm x command`.

Closes #90.