### PR TITLE
Added rewind-to command

### DIFF
--- a/packages/client/src/fm-player/services/event-stream-client.ts
+++ b/packages/client/src/fm-player/services/event-stream-client.ts
@@ -56,6 +56,10 @@ function connect(): (() => void) {
         PlayerStateService.replaceQueue(eventData.songs);
         break;
 
+      case 'RewindToEvent':
+        YouTubePlayerService.rewindTo(eventData.time);
+        break;
+
       default:
         break;
     }

--- a/packages/client/src/fm-player/services/youtube-player-service.ts
+++ b/packages/client/src/fm-player/services/youtube-player-service.ts
@@ -77,6 +77,11 @@ function setSpeed(nextSpeed: SpeedControl) {
   }
 }
 
+function rewindTo(time: number) {
+  player.seek(time);
+  done();
+}
+
 function initialize(playerContainerDomId: string) {
   player = new YTPlayer(`#${playerContainerDomId}`);
 
@@ -138,4 +143,5 @@ export {
   playNextSong,
   setVolume,
   setSpeed,
+  rewindTo,
 };

--- a/packages/service/src/domain/commands/processors/rewind-to-command.ts
+++ b/packages/service/src/domain/commands/processors/rewind-to-command.ts
@@ -1,0 +1,66 @@
+import { Command } from '@service/domain/commands/model/command';
+import { CommandProcessingResponse, CommandProcessingResponseBuilder } from '@service/domain/commands/model/command-processing-response';
+import { CommandParameters, CommandParametersBuilder, CommandProcessor } from '@service/domain/commands/model/command-processor';
+import { RegisterCommand } from '@service/domain/commands/registry/register-command';
+import { RewindToEvent } from '@service/event-stream/model/events';
+import { PlayerEventStream } from '@service/event-stream/player-event-stream';
+import { parseToSeconds } from '@service/utils/utils';
+import { Service } from 'typedi';
+
+@RegisterCommand
+@Service()
+class RewindToCommand extends CommandProcessor {
+  constructor(private playerEventStream: PlayerEventStream) {
+    super();
+  }
+
+  async execute(command: Command): Promise<CommandProcessingResponse> {
+    const timeArgument = command.rawArgs;
+    if (!timeArgument) {
+      throw new Error('You have to provide time to skip');
+    }
+
+    const time = parseToSeconds(timeArgument);
+
+    if (time === null) {
+      throw new Error('Wrong argument. You have to provide time in seconds or hh:mm:ss format.');
+    }
+    const event: RewindToEvent = {
+      id: 'RewindToEvent',
+      time,
+    };
+
+    this.playerEventStream.sendToEveryone(event);
+
+    return new CommandProcessingResponseBuilder()
+      .fromMarkdown(`Przewijamy do ${timeArgument}`)
+      .build();
+  }
+
+  get key(): string {
+    return 'rewind-to';
+  }
+
+  get shortKey(): (string | null) {
+    return null;
+  }
+
+  get helpMessage(): string {
+    return 'Przewija filmik do x sekund';
+  }
+
+  get exampleUsages(): string[] {
+    return [
+      '10',
+      '90',
+    ];
+  }
+
+  get parameters(): CommandParameters {
+    return new CommandParametersBuilder()
+      .withRequired('time')
+      .build();
+  }
+}
+
+export { RewindToCommand };

--- a/packages/service/src/domain/commands/processors/rewind-to-command.ts
+++ b/packages/service/src/domain/commands/processors/rewind-to-command.ts
@@ -17,13 +17,13 @@ class RewindToCommand extends CommandProcessor {
   async execute(command: Command): Promise<CommandProcessingResponse> {
     const timeArgument = command.rawArgs;
     if (!timeArgument) {
-      throw new Error('You have to provide time to skip');
+      throw new Error('Brak wymaganego argumentu. Wymagane podanie czasu w sekundach lub w formacie hh:mm:ss.');
     }
 
     const time = parseToSeconds(timeArgument);
 
     if (time === null) {
-      throw new Error('Wrong argument. You have to provide time in seconds or hh:mm:ss format.');
+      throw new Error('Niepoprawny argument. Wymagane podanie czasu w sekundach lub w formacie hh:mm:ss.');
     }
 
     const event: RewindToEvent = {

--- a/packages/service/src/domain/commands/processors/rewind-to-command.ts
+++ b/packages/service/src/domain/commands/processors/rewind-to-command.ts
@@ -25,6 +25,7 @@ class RewindToCommand extends CommandProcessor {
     if (time === null) {
       throw new Error('Wrong argument. You have to provide time in seconds or hh:mm:ss format.');
     }
+
     const event: RewindToEvent = {
       id: 'RewindToEvent',
       time,
@@ -46,13 +47,14 @@ class RewindToCommand extends CommandProcessor {
   }
 
   get helpMessage(): string {
-    return 'Przewija filmik do x sekund';
+    return 'Przewija filmik do podanego czasu w sekundach lub formacie hh:mm:ss';
   }
 
   get exampleUsages(): string[] {
     return [
       '10',
       '90',
+      '1:30',
     ];
   }
 

--- a/packages/service/src/domain/commands/processors/song-add-command.ts
+++ b/packages/service/src/domain/commands/processors/song-add-command.ts
@@ -3,6 +3,7 @@ import { CommandProcessingResponse, CommandProcessingResponseBuilder } from '@se
 import { CommandParameters, CommandParametersBuilder, CommandProcessor } from '@service/domain/commands/model/command-processor';
 import { RegisterCommand } from '@service/domain/commands/registry/register-command';
 import { SongsService } from '@service/domain/songs/songs-service';
+import { parseToSeconds } from '@service/utils/utils';
 import { YouTubeDataClient } from '@service/youtube/youtube-data-client';
 import { Service } from 'typedi';
 
@@ -33,30 +34,13 @@ class SongAddCommand extends CommandProcessor {
       throw new Error('Ten plik nie jest obsługiwany przez osadzony odtwarzacz');
     }
 
-    const trimStartSeconds = trimStart ? this.parseTimeStringToSeconds(trimStart) : null;
-    const trimEndSeconds = trimEnd ? this.parseTimeStringToSeconds(trimEnd) : null;
+    const trimStartSeconds = trimStart ? parseToSeconds(trimStart) : null;
+    const trimEndSeconds = trimEnd ? parseToSeconds(trimEnd) : null;
     this.songService.createNewSong(youtubeId, name, 0, trimStartSeconds, trimEndSeconds);
 
     return new CommandProcessingResponseBuilder()
       .fromMarkdown(`Dodano utwór "${name}" do biblioteki`)
       .build();
-  }
-
-  private parseTimeStringToSeconds(text: string): number {
-    const [minutes, seconds] = text.split(':');
-
-    if (!minutes || !seconds) {
-      throw new Error('Niepoprawny format czasu');
-    }
-
-    const parsedMinutes = parseInt(minutes, 10);
-    const parsedSeconds = parseInt(seconds, 10);
-
-    if (Number.isNaN(parsedMinutes) || Number.isNaN(parsedSeconds)) {
-      throw new Error('Niepoprawny format czasu');
-    }
-
-    return ((parsedMinutes * 60) + parsedSeconds);
   }
 
   get key(): string {

--- a/packages/service/src/domain/commands/processors/song-add-command.ts
+++ b/packages/service/src/domain/commands/processors/song-add-command.ts
@@ -34,8 +34,16 @@ class SongAddCommand extends CommandProcessor {
       throw new Error('Ten plik nie jest obsługiwany przez osadzony odtwarzacz');
     }
 
-    const trimStartSeconds = trimStart ? parseToSeconds(trimStart) : null;
-    const trimEndSeconds = trimEnd ? parseToSeconds(trimEnd) : null;
+    const trimStartSeconds = parseToSeconds(trimStart);
+    const trimEndSeconds = parseToSeconds(trimEnd);
+
+    if (
+      (trimStart && trimStartSeconds === null) ||
+      (trimEnd && trimEndSeconds === null)
+    ) {
+      throw new Error('Niepoprawny format czasu');
+    }
+
     this.songService.createNewSong(youtubeId, name, 0, trimStartSeconds, trimEndSeconds);
 
     return new CommandProcessingResponseBuilder()

--- a/packages/service/src/event-stream/model/events.ts
+++ b/packages/service/src/event-stream/model/events.ts
@@ -51,6 +51,11 @@ export interface ChangeVolumeEvent {
   nextVolume: number,
 }
 
+export interface RewindToEvent {
+  id: 'RewindToEvent',
+  time: number,
+}
+
 export type EventData =
   | PlayerStateUpdateEvent
   | PlayerStateRequestEvent
@@ -61,4 +66,5 @@ export type EventData =
   | SkipEvent
   | ChangeSpeedEvent
   | ChangeVolumeEvent
-  | ReplaceQueueEvent;
+  | ReplaceQueueEvent
+  | RewindToEvent;

--- a/packages/service/src/utils/__tests__/utils.spec.ts
+++ b/packages/service/src/utils/__tests__/utils.spec.ts
@@ -1,0 +1,20 @@
+import { parseToSeconds } from '../utils';
+
+describe('parseToSeconds', () => {
+  [
+    { given: '30', expected: 30 },
+    { given: '1:30', expected: 90 },
+    { given: '1:30:01', expected: 5401 },
+    { given: '1:00:00', expected: 3600 },
+    { given: '1:0:0', expected: 3600 },
+    { given: '1:1:00', expected: 3660 },
+    { given: '1:bla:01', expected: null },
+    { given: 'bla:bla:01', expected: null },
+    { given: '1:10120:00', expected: null },
+    { given: '1:21:37:00', expected: null },
+  ].forEach(({ given, expected }) => {
+    it(`should return ${expected} seconds when ${given} is given`, () => {
+      expect(parseToSeconds(given)).toBe(expected);
+    });
+  });
+});

--- a/packages/service/src/utils/utils.ts
+++ b/packages/service/src/utils/utils.ts
@@ -20,3 +20,26 @@ export function extractSessionFromIncomingMessage(incomingMessage: IncomingMessa
   // @ts-ignore Trust me, there is session in message
   return incomingMessage.session;
 }
+
+export function parseToSeconds(time: string): number | null {
+  const splitedTime = time.split(':');
+  if (!splitedTime.length || splitedTime.length > 3) {
+    return null;
+  }
+
+  if (splitedTime.length === 1) {
+    const seconds = parseInt(splitedTime[0], 10);
+    return !Number.isNaN(seconds) ? seconds : null;
+  }
+
+  const timeParts = splitedTime.map((timePart) => parseInt(timePart, 10));
+  const isValid = !timeParts.some((timePart) => Number.isNaN(timePart) || timePart > 60);
+
+  if (!isValid) {
+    return null;
+  }
+
+  return timeParts
+    .reverse()
+    .reduce((sum, timePart, index) => sum + timePart * (60 ** index), 0);
+}

--- a/packages/service/src/utils/utils.ts
+++ b/packages/service/src/utils/utils.ts
@@ -21,7 +21,11 @@ export function extractSessionFromIncomingMessage(incomingMessage: IncomingMessa
   return incomingMessage.session;
 }
 
-export function parseToSeconds(time: string): number | null {
+export function parseToSeconds(time?: string): number | null {
+  if (!time) {
+    return null;
+  }
+
   const splitedTime = time.split(':');
   if (!splitedTime.length || splitedTime.length > 3) {
     return null;


### PR DESCRIPTION
Dodana nowa komenda: `/fm rewind-to $time`.

Pozwala na przewinięcie bieżącego utworu do podanego czasu. 
Czas można podawać w dwóch formatach:
 - w sekundach np.: `/fm rewind-to 30` - przewija utwór do 0:30 (m:s)
 - w formacie _**hh:mm:ss**_ / _**mm:ss**_ np.: `/fm rewind-to 1:30` - przewija utwór do 1:30 (m:s).

Dajcie znać co myślicie :).