### PR TITLE
API x-sounds/tags endpoints

### DIFF
--- a/packages/service/src/api/x-sounds/model/xsounds-response-dto.ts
+++ b/packages/service/src/api/x-sounds/model/xsounds-response-dto.ts
@@ -4,4 +4,8 @@ interface XSoundsResponseDto {
   sounds: XSound[],
 }
 
-export { XSoundsResponseDto };
+interface XSoundsTagsResponseDto {
+  tags: string[],
+}
+
+export { XSoundsResponseDto, XSoundsTagsResponseDto };

--- a/packages/service/src/api/x-sounds/x-sounds-controller.ts
+++ b/packages/service/src/api/x-sounds/x-sounds-controller.ts
@@ -1,10 +1,10 @@
 import { Service } from 'typedi';
-import { Controller, BodyParam, Post, Get, UploadedFile, ContentType, Authorized, CurrentUser, InternalServerError } from 'routing-controllers';
+import { Controller, BodyParam, Post, Get, UploadedFile, ContentType, Authorized, CurrentUser, InternalServerError, Param, NotFoundError } from 'routing-controllers';
 import { MissingRequriedFieldsError } from '@service/api/x-sounds/model/missing-required-fields-error';
 import { XSound } from '@service/domain/x-sounds/x-sound';
 import { XSoundsService } from '@service/domain/x-sounds/x-sounds-service';
 import { Logger } from '@service/infrastructure/logger';
-import { XSoundsResponseDto } from '@service/api/x-sounds/model/xsounds-response-dto';
+import { XSoundsResponseDto, XSoundsTagsResponseDto } from '@service/api/x-sounds/model/xsounds-response-dto';
 import { User } from '@service/domain/users/user';
 
 @Service()
@@ -19,6 +19,25 @@ class XSoundsController {
   @ContentType('application/json')
   async getXSounds(): Promise<XSoundsResponseDto> {
     const sounds = await this.xSoundsService.getAll();
+    return { sounds };
+  }
+
+  @Get('/tags')
+  @ContentType('application/json')
+  async getXSoundsAllTags(): Promise<XSoundsTagsResponseDto> {
+    const tags = await this.xSoundsService.getAllUniqueTags();
+    return { tags };
+  }
+
+  @Get('/tags/:tag')
+  @ContentType('application/json')
+  async getXSoundsByTag(
+    @Param('tag') tag: string,
+  ): Promise<XSoundsResponseDto> {
+    const sounds = await this.xSoundsService.getAllByTag(tag);
+    if (!sounds.length) {
+      throw new NotFoundError('Invalid tag. No sounds found.');
+    }
     return { sounds };
   }
 


### PR DESCRIPTION
Dodałem endpointy do pobierania tagów i dzwięków po tagu. Będę potrzebował ich do nowego soundboarda.
Nie robiłem nowego controllera na rucie /api/tags dla tagów, tylko dorzuciłem to w tym do api/x-sounds bo w xSoundService miałem wszystkie metody, do pobierania ich i nie chciałem dublować/przenosić.