### PR TITLE
Socket auth via API token

### DIFF
--- a/packages/service/src/domain/auth/auth-service.ts
+++ b/packages/service/src/domain/auth/auth-service.ts
@@ -8,7 +8,7 @@ import { Service } from 'typedi';
 class AuthService {
   private static logger = new Logger('auth-service');
 
-  constructor(private usersService: UsersService) {}
+  constructor(private usersService: UsersService) { }
 
   async authorize(username: string, password: string, session: RequestSession): Promise<void> {
     const userExists = await this.usersService.doesUserExist(username);
@@ -50,14 +50,14 @@ class AuthService {
     return (isSessionAuthorized || isApiTokenAuthorized);
   }
 
-  async getRequestsUser(session: RequestSession, token: (string | null)): Promise<User| null> {
+  async getRequestsUser(session: RequestSession, token: (string | null)): Promise<User | null> {
     const userFromSession = await this.getUserFromSession(session);
     const userFromToken = token ? await this.usersService.getByApiToken(token) : null;
     return userFromSession || userFromToken;
   }
 
-  async isWebSocketAuthorized(session: RequestSession): Promise<boolean> {
-    return this.isSessionAuthorized(session);
+  async isWebSocketAuthorized(session: RequestSession, token: (string | null)): Promise<boolean> {
+    return this.isRequestAuthorized(session, token);
   }
 
   private async getUserFromSession(session: RequestSession): Promise<User | null> {

--- a/packages/service/src/main.ts
+++ b/packages/service/src/main.ts
@@ -97,7 +97,8 @@ async function main(): Promise<void> {
   const ioSessionMiddleware = expressMiddlewareToSocketIoMiddleware(sessionMiddleware);
   const ioAuthorizationChecker = async (socket: SocketIO.Socket, next: Function): Promise<void | Error> => {
     const requestSession: RequestSession = extractSessionFromIncomingMessage(socket.request);
-    const isSessionAuthorized: boolean = await Container.get(AuthService).isWebSocketAuthorized(requestSession);
+    const token = (socket.handshake.auth.token || null) as (string | null);
+    const isSessionAuthorized: boolean = await Container.get(AuthService).isWebSocketAuthorized(requestSession, token);
     if (isSessionAuthorized) {
       next();
     } else {


### PR DESCRIPTION
You can now authenticate socket connections without session token, by using API token.

Passing API token is handled via handshake object when creating sockets:
```javascript
const socket = io({
  auth: {
    token: "user-token"
  }
});
```

@gorzalczany you might want to take a look at this :)