### PR TITLE
add mongo db to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,5 +301,12 @@ Alternatively you can run it as an yarn command from the root of the project:
 Helper script `scripts/docker_db_local.sh` runs MongoDB and binds ports for local development.\
 To stop container run `scripts/docker_db_local.sh stop`.
 
+#### Docker compose
+You can also run this app via docker compose. It has mongo db already configured. Just pass other necessary config variables.
+```sh
+docker compose up --build
+```
+
+
 ## License
 This project is licensed under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Helper script `scripts/docker_db_local.sh` runs MongoDB and binds ports for loca
 To stop container run `scripts/docker_db_local.sh stop`.
 
 #### Docker compose
-You can also run this app via docker compose. It has mongo db already configured. Just pass other necessary config variables.
+You can also run this app via Docker Compose. It has MongoDB already configured. Just pass other necessary config variables.
 ```sh
 docker compose up --build
 ```

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Alternatively you can run it as an yarn command from the root of the project:
 Helper script `scripts/docker_db_local.sh` runs MongoDB and binds ports for local development.\
 To stop container run `scripts/docker_db_local.sh stop`.
 
-#### Docker compose
+#### Docker Compose
 You can also run this app via Docker Compose. It has MongoDB already configured. Just pass other necessary config variables.
 ```sh
 docker compose up --build

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,5 +8,21 @@ services:
       context: .
     environment:
       NODE_ENV: production
+      MONGODB_URI: mongodb://mongo:27017
     ports:
       - 9000:9000
+    networks:
+      - lebkuchen-network
+    depends_on:
+     - mongo
+  mongo:
+    container_name: lebkuchen-fm-db-local
+    image: mongo:latest
+    ports:
+      - 27017:27017
+    networks:
+      - lebkuchen-network
+
+networks:
+  lebkuchen-network:
+    driver: bridge


### PR DESCRIPTION
What:
- mongodb in docker compose

Why:
- simplify development process
- example for self-hosted instances of lebkuchen-fm