### PR TITLE
split play-pause functionality into separate commands

### DIFF
--- a/packages/client/src/fm-player/services/event-stream-client.ts
+++ b/packages/client/src/fm-player/services/event-stream-client.ts
@@ -39,8 +39,12 @@ function connect(): (() => void) {
         SpeechService.say(eventData.text);
         break;
 
-      case 'PlayPauseEvent':
-        YouTubePlayerService.playPause();
+      case 'PauseEvent':
+        YouTubePlayerService.pause();
+        break;
+
+      case 'ResumeEvent':
+        YouTubePlayerService.resume();
         break;
 
       case 'SkipEvent': {

--- a/packages/client/src/fm-player/services/youtube-player-service.ts
+++ b/packages/client/src/fm-player/services/youtube-player-service.ts
@@ -37,15 +37,15 @@ function playNextSong() {
   done();
 }
 
-function playPause() {
-  const { isPlaying } = PlayerStateService.getState();
-  if (isPlaying) {
-    player.pause();
-  } else {
-    player.play();
-  }
+function pause() {
+  player.pause();
+  PlayerStateService.getState().isPlaying = false;
+  done();
+}
 
-  PlayerStateService.getState().isPlaying = !isPlaying;
+function resume() {
+  player.play();
+  PlayerStateService.getState().isPlaying = true;
   done();
 }
 
@@ -155,7 +155,8 @@ function initialize(playerContainerDomId: string) {
 
 export {
   initialize,
-  playPause,
+  resume,
+  pause,
   playNextSong,
   setVolume,
   setSpeed,

--- a/packages/service/src/domain/commands/processors/playback-pause-command.ts
+++ b/packages/service/src/domain/commands/processors/playback-pause-command.ts
@@ -2,27 +2,36 @@ import { Command } from '@service/domain/commands/model/command';
 import { CommandProcessingResponse, CommandProcessingResponseBuilder } from '@service/domain/commands/model/command-processing-response';
 import { CommandParameters, CommandParametersBuilder, CommandProcessor } from '@service/domain/commands/model/command-processor';
 import { RegisterCommand } from '@service/domain/commands/registry/register-command';
+import { PlayerPauseEvent } from '@service/event-stream/model/events';
+import { PlayerEventStream } from '@service/event-stream/player-event-stream';
 import { Service } from 'typedi';
 
 @RegisterCommand
 @Service()
-class PlayPauseCommand extends CommandProcessor {
+class PauseCommand extends CommandProcessor {
+  constructor(private playerEventStream: PlayerEventStream) {
+    super();
+  }
+
   async execute(_: Command): Promise<CommandProcessingResponse> {
+    const event: PlayerPauseEvent = { id: 'PauseEvent' };
+    this.playerEventStream.sendToEveryone(event);
+
     return new CommandProcessingResponseBuilder()
-      .fromMarkdown(this.helpMessage)
+      .fromMarkdown('⏸️')
       .build();
   }
 
   get key(): string {
-    return 'playback-play-pause';
+    return 'playback-pause';
   }
 
   get shortKey(): (string | null) {
-    return 'play';
+    return 'pause';
   }
 
   get helpMessage(): string {
-    return '`@Deprecated` użyj bardziej precyzyjnych komend `resume`/`pause`';
+    return 'Zatrzymuje bieżący film';
   }
 
   get exampleUsages(): string[] {
@@ -36,4 +45,4 @@ class PlayPauseCommand extends CommandProcessor {
   }
 }
 
-export { PlayPauseCommand };
+export { PauseCommand as PlayPauseCommand };

--- a/packages/service/src/domain/commands/processors/playback-resume-command.ts
+++ b/packages/service/src/domain/commands/processors/playback-resume-command.ts
@@ -2,27 +2,36 @@ import { Command } from '@service/domain/commands/model/command';
 import { CommandProcessingResponse, CommandProcessingResponseBuilder } from '@service/domain/commands/model/command-processing-response';
 import { CommandParameters, CommandParametersBuilder, CommandProcessor } from '@service/domain/commands/model/command-processor';
 import { RegisterCommand } from '@service/domain/commands/registry/register-command';
+import { PlayerResumeEvent } from '@service/event-stream/model/events';
+import { PlayerEventStream } from '@service/event-stream/player-event-stream';
 import { Service } from 'typedi';
 
 @RegisterCommand
 @Service()
-class PlayPauseCommand extends CommandProcessor {
+class PlayCommand extends CommandProcessor {
+  constructor(private playerEventStream: PlayerEventStream) {
+    super();
+  }
+
   async execute(_: Command): Promise<CommandProcessingResponse> {
+    const event: PlayerResumeEvent = { id: 'ResumeEvent' };
+    this.playerEventStream.sendToEveryone(event);
+
     return new CommandProcessingResponseBuilder()
-      .fromMarkdown(this.helpMessage)
+      .fromMarkdown('▶️')
       .build();
   }
 
   get key(): string {
-    return 'playback-play-pause';
+    return 'playback-resume';
   }
 
   get shortKey(): (string | null) {
-    return 'play';
+    return 'resume';
   }
 
   get helpMessage(): string {
-    return '`@Deprecated` użyj bardziej precyzyjnych komend `resume`/`pause`';
+    return 'Wznawia otwarzanie zatrzymanego lub zakończonego wideo';
   }
 
   get exampleUsages(): string[] {
@@ -36,4 +45,4 @@ class PlayPauseCommand extends CommandProcessor {
   }
 }
 
-export { PlayPauseCommand };
+export { PlayCommand as PlayPauseCommand };

--- a/packages/service/src/domain/commands/processors/playback-rewind-command.ts
+++ b/packages/service/src/domain/commands/processors/playback-rewind-command.ts
@@ -54,15 +54,15 @@ class RewindCommand extends CommandProcessor {
   }
 
   get key(): string {
-    return 'rewind';
+    return 'playback-rewind';
   }
 
   get shortKey(): (string | null) {
-    return null;
+    return 'rewind';
   }
 
   get helpMessage(): string {
-    return 'Przewija filmik do podanego czasu lub o podany czas(modyfikatory +/-)';
+    return 'Przewija odtwarzane wideo do podanego czasu lub o podany czas(modyfikatory +/-)';
   }
 
   get exampleUsages(): string[] {

--- a/packages/service/src/event-stream/model/events.ts
+++ b/packages/service/src/event-stream/model/events.ts
@@ -72,7 +72,8 @@ export type EventData =
   | AddSongsToQueueEvent
   | PlayXSoundEvent
   | SayEvent
-  | PlayPauseEvent
+  | PlayerPauseEvent
+  | PlayerResumeEvent
   | SkipEvent
   | ChangeSpeedEvent
   | ChangeVolumeEvent

--- a/packages/service/src/event-stream/model/events.ts
+++ b/packages/service/src/event-stream/model/events.ts
@@ -29,8 +29,12 @@ export interface SayEvent {
   text: string,
 }
 
-export interface PlayPauseEvent {
-  id: 'PlayPauseEvent',
+export interface PlayerResumeEvent {
+  id: 'ResumeEvent',
+}
+
+export interface PlayerPauseEvent {
+  id: 'PauseEvent',
 }
 
 export interface SkipEvent {


### PR DESCRIPTION
#Why:
- avoid confusion when some players changed state locally (local pause)
- enable "force play" when some players have problem
- enable play again on finished song that was last in the queue