### PR TITLE
[beta backend] fix help message commands params

### DIFF
--- a/service/src/main/kotlin/xyz/lebkuchenfm/domain/commands/processors/HelpCommandProcessor.kt
+++ b/service/src/main/kotlin/xyz/lebkuchenfm/domain/commands/processors/HelpCommandProcessor.kt
@@ -77,9 +77,7 @@ class HelpCommandProcessor(private val commandPrompt: String) :
         val command = commandsRegistry.getProcessorByKey(commandName)
             ?: return error("No such command: $commandName", logger)
 
-        val exampleText = command.exampleUsages
-            .map { usage -> "  $commandPrompt $commandName $usage" }
-            .joinToString("\n")
+        val exampleText = command.exampleUsages.joinToString("\n") { usage -> "  $commandPrompt $commandName $usage" }
 
         return CommandProcessingResult.fromMultilineMarkdown(
             "```",
@@ -97,14 +95,13 @@ class HelpCommandProcessor(private val commandPrompt: String) :
         val key = definition.key
         val parameters = definition.parameters
 
-        val paramsText = parameters.parameters
-            .map { param ->
-                val joinedParams = param.names.joinToString(" | ")
-                when (param.required) {
-                    true -> "<$joinedParams>"
-                    false -> "[$joinedParams]"
-                }
-            }.joinToString { parameters.delimiter ?: "" }
+        val paramsText = parameters.parameters.joinToString(parameters.delimiter ?: "") { param ->
+            val joinedParams = param.names.joinToString(" | ")
+            when (param.required) {
+                true -> "<$joinedParams>"
+                false -> "[$joinedParams]"
+            }
+        }
 
         return "$key $paramsText"
     }


### PR DESCRIPTION
### What:
- fix help message

### Why:
- parameters string building function was incorrect resulting with no information about them

### Examples
<details>
  <summary>[click me] help params</summary>

  - before:
  
      ```
        help
        
        > Displays available commands and examples of their usage.
      ```
  
  - after:
  
      ```
        help [command-name]
        
        > Displays available commands and examples of their usage.
      ```
</details>

<details>
  <summary>[click me] song-queue params</summary>

  - before:
  
      ```
      song-queue
      
      > Adds a song from the database to the queue, and if it is not there,
      treats the phrase as a YouTube video ID or YouTube playlist ID.
      
      Examples:
        /fmbeta q transatlantik
        /fmbeta q p28K7Fz0KrQ
        /fmbeta q PLpdRVFVH_vIMvkMVdJScNK3S2SeOv7k1d
      ```
  
  - after:
  
      ```
      song-queue <video-name | youtube-id | youtube-playlist-id>
      
      > Adds a song from the database to the queue, and if it is not there,
      treats the phrase as a YouTube video ID or YouTube playlist ID.
      
      Examples:
        /fmbeta q transatlantik
        /fmbeta q p28K7Fz0KrQ
        /fmbeta q PLpdRVFVH_vIMvkMVdJScNK3S2SeOv7k1d
      ```
</details>
