### PR TITLE
Remove all references to legacy service

### DIFF
--- a/packages/client-beta/package.json
+++ b/packages/client-beta/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@solidjs/router": "0.13.0",
-    "lebkuchen-fm-service": "*",
     "mitt": "3.0.1",
     "solid-js": "1.8.15",
     "yt-player": "3.6.1"

--- a/packages/client-beta/src/apps/Player/services/youtube-player-service.tsx
+++ b/packages/client-beta/src/apps/Player/services/youtube-player-service.tsx
@@ -13,7 +13,7 @@ import type {
   RewindEvent,
   SkipEvent,
   SongChangedEvent,
-} from '@service/event-stream/model/events';
+} from '../../../types/event-data';
 import { PlayerStateService } from './player-state-service';
 import { SocketConnectionClient } from '../../../services/socket-connection-client';
 import { LocalEventTypes, PlayerStateRequestEventResponse } from '../../../types/local-events';

--- a/packages/client-beta/src/apps/Soundboard/Soundboard.tsx
+++ b/packages/client-beta/src/apps/Soundboard/Soundboard.tsx
@@ -1,7 +1,6 @@
 import { AppWindow } from '@components/AppWindow/AppWindow';
 import { DesktopIcon } from '@components/DesktopIcon/DesktopIcon';
 import { createEffect, createSignal, For } from 'solid-js';
-import { XSound } from '@service/domain/x-sounds/x-sound';
 import soundboardIcon from '../../icons/soundboard-icon.svg';
 import styles from './Soundboard.module.css';
 import {
@@ -10,6 +9,7 @@ import {
   soundMatchesPhrase,
   soundsSorting,
 } from '../../services/soundboard-service';
+import { XSound } from '../../types/x-sound';
 
 function Soundboard() {
   const [showWindow, setShowWindow] = createSignal(false);

--- a/packages/client-beta/src/services/soundboard-service.ts
+++ b/packages/client-beta/src/services/soundboard-service.ts
@@ -1,4 +1,4 @@
-import { XSound } from '@service/domain/x-sounds/x-sound';
+import { XSound } from '../types/x-sound';
 
 export async function getXSounds() {
   return fetch('/api/x-sounds')

--- a/packages/client-beta/src/types/event-data.ts
+++ b/packages/client-beta/src/types/event-data.ts
@@ -1,0 +1,87 @@
+import { PlayerState, Song } from './player-state';
+
+export interface PlayerStateUpdateEvent {
+  id: 'PlayerStateUpdateEvent';
+  state: PlayerState;
+}
+
+export interface PlayerStateRequestEvent {
+  id: 'PlayerStateRequestEvent';
+}
+
+export interface AddSongsToQueueEvent {
+  id: 'AddSongsToQueueEvent';
+  songs: Song[];
+}
+export interface ReplaceQueueEvent {
+  id: 'ReplaceQueueEvent';
+  songs: Song[];
+}
+
+export interface PlayXSoundEvent {
+  id: 'PlayXSoundEvent';
+  soundUrl: string;
+}
+
+export interface SayEvent {
+  id: 'SayEvent';
+  text: string;
+}
+
+export interface PlayerResumeEvent {
+  id: 'ResumeEvent';
+}
+
+export interface PlayerPauseEvent {
+  id: 'PauseEvent';
+}
+
+export interface SkipEvent {
+  id: 'SkipEvent';
+  skipAll: boolean;
+  amount: number;
+}
+
+export type SpeedControl = -1 | 0 | 1;
+export interface ChangeSpeedEvent {
+  id: 'ChangeSpeedEvent';
+  nextSpeed: SpeedControl;
+}
+
+export interface ChangeVolumeEvent {
+  id: 'ChangeVolumeEvent';
+  isRelative: boolean;
+  nextVolume: number;
+}
+
+export interface RewindEvent {
+  id: 'RewindEvent';
+  time: number;
+  modifier: number | null;
+}
+
+export interface SongChangedEvent {
+  id: 'SongChanged';
+  song: Song;
+}
+
+export interface ConnectedUsersEvent {
+  id: 'ConnectedUsersEvent';
+  connectedUsers: string[];
+}
+
+export type EventData =
+  | PlayerStateUpdateEvent
+  | PlayerStateRequestEvent
+  | AddSongsToQueueEvent
+  | PlayXSoundEvent
+  | SayEvent
+  | PlayerPauseEvent
+  | PlayerResumeEvent
+  | SkipEvent
+  | ChangeSpeedEvent
+  | ChangeVolumeEvent
+  | ReplaceQueueEvent
+  | RewindEvent
+  | ConnectedUsersEvent
+  | SongChangedEvent;

--- a/packages/client-beta/src/types/local-events.ts
+++ b/packages/client-beta/src/types/local-events.ts
@@ -1,5 +1,5 @@
 import type { PlayerState } from './player-state';
-import type { EventData } from '@service/event-stream/model/events';
+import { EventData } from './event-data';
 
 enum LocalEventTypes {
   LocalPlayerStateUpdate = 'LocalPlayerStateUpdate',

--- a/packages/client-beta/src/types/x-sound.ts
+++ b/packages/client-beta/src/types/x-sound.ts
@@ -1,0 +1,9 @@
+interface XSound {
+  name: string;
+  url: string;
+  timesPlayed: number;
+  tags: string[];
+  addedBy?: string;
+}
+
+export { XSound };

--- a/packages/client-beta/tsconfig.json
+++ b/packages/client-beta/tsconfig.json
@@ -18,7 +18,6 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@service/*": ["../service/src/*"],
       "@components/*": ["./src/components/*"],
       "*": ["node_modules/*"]
     },


### PR DESCRIPTION
Why: We want to move away from legacy code. New data types will eventually be generated by new backend, but for now I would prefer to have them separate (especially when the new data types are different from the old ones).