### PR TITLE
improve app title bar

### DIFF
--- a/client/src/components/AppWindow/AppWindow.tsx
+++ b/client/src/components/AppWindow/AppWindow.tsx
@@ -3,6 +3,7 @@ import { JSX } from 'solid-js';
 import styles from './AppWindow.module.css';
 import { AppIcon } from '@components/AppIcon/AppIcon';
 import { IconSpriteIndex } from '@components/AppIcon/IconSpritesheet';
+import { PhIcon, PhIconType } from '@components/PhIcon/PhIcon';
 
 interface AppWindowProps {
   children: JSX.Element;
@@ -19,7 +20,8 @@ interface AppWindowProps {
   title: string;
   close?: () => void;
   centered?: boolean;
-  iconIndex: IconSpriteIndex;
+  iconIndex?: IconSpriteIndex;
+  phIcon?: { type: PhIconType; icon: string };
 }
 
 function AppWindow(props: AppWindowProps) {
@@ -119,7 +121,8 @@ function AppWindow(props: AppWindowProps) {
       }}
     >
       <div class={styles.title} onMouseDown={dragMouseDown}>
-        <AppIcon size={16} iconIndex={props.iconIndex} />
+        {props.iconIndex && <AppIcon size={16} iconIndex={props.iconIndex} />}
+        {props.phIcon && <PhIcon type={props.phIcon.type} icon={props.phIcon.icon} size={16} />}
         <p class={styles.titleText}>{props.title}</p>
         {!!props.close && (
           <button type="button" class={styles.close} onClick={closeWindow}>

--- a/client/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/client/src/components/ErrorDialog/ErrorDialog.tsx
@@ -2,7 +2,6 @@ import { Component } from 'solid-js';
 import { AppWindow } from '@components/AppWindow/AppWindow';
 import { Button } from '@components/Button/Button';
 import { PhIcon, PhIconType } from '@components/PhIcon/PhIcon';
-import { USER_MANAGER_ICON_INDEX } from '@components/AppIcon/IconSpritesheet';
 import styles from './ErrorDialog.module.css';
 
 interface ErrorDialogProps {
@@ -17,12 +16,12 @@ const ErrorDialog: Component<ErrorDialogProps> = (props) => {
       close={props.close}
       centered
       startSize={{ width: '300px', height: '180px' }}
-      iconIndex={USER_MANAGER_ICON_INDEX}
+      phIcon={{ type: PhIconType.Bold, icon: 'warning-octagon' }}
     >
       <div class={styles.container}>
         <div class={styles.body}>
           <span class={styles.icon}>
-            <PhIcon type={PhIconType.Fill} icon="warning-circle" />
+            <PhIcon type={PhIconType.Bold} icon="warning-octagon" />
           </span>
           <p class={styles.message}>{props.message}</p>
         </div>

--- a/client/src/components/PhIcon/PhIcon.module.css
+++ b/client/src/components/PhIcon/PhIcon.module.css
@@ -1,5 +1,3 @@
 .phIcon {
-  width: 24px;
-  height: 24px;
-  line-height: 24px;
+  display: inline-block;
 }

--- a/client/src/components/PhIcon/PhIcon.tsx
+++ b/client/src/components/PhIcon/PhIcon.tsx
@@ -9,10 +9,18 @@ enum PhIconType {
 interface PhIconProps {
   type: PhIconType;
   icon: string;
+  size?: number;
 }
 
 function PhIcon(props: PhIconProps) {
-  return <i class={clsx(styles.phIcon, `ph-${props.type}`, `ph-${props.icon}`)} />;
+  const size = () => `${props.size ?? 24}px`;
+
+  return (
+    <i
+      class={clsx(styles.phIcon, `ph-${props.type}`, `ph-${props.icon}`)}
+      style={{ width: size(), height: size(), 'line-height': size(), 'font-size': size() }}
+    />
+  );
 }
 
 export { PhIcon, PhIconType };


### PR DESCRIPTION
### What:
- enable phosphor icons in app title bar

### Why:
- improve its flexibility